### PR TITLE
iNToRecFN num_zero_o fix width

### DIFF
--- a/source/iNToRecFN.v
+++ b/source/iNToRecFN.v
@@ -64,12 +64,15 @@ module
     wire [(expWidth - 2):0] adjustedNormDist;
     //countLeadingZeros#(extIntWidth, expWidth - 1)
     //    countLeadingZeros(extAbsIn, adjustedNormDist);
+    logic [$clog2(extIntWidth+1)-1:0] num_zero_lo;
     bsg_counting_leading_zeros #(
       .width_p(extIntWidth)
     ) clz (
       .a_i(extAbsIn)
-      ,.num_zero_o(adjustedNormDist)
+      ,.num_zero_o(num_zero_lo)
     );
+    assign adjustedNormDist = (expWidth-1)'(num_zero_lo);
+    
     /*------------------------------------------------------------------------
     *------------------------------------------------------------------------*/
     assign sig = (extAbsIn<<adjustedNormDist)>>(extIntWidth - intWidth);


### PR DESCRIPTION
Fix synth issue:
Error: Width mismatch on port 'num_zero_o' of reference to 'bsg_counting_leading_zeros' in 'iNToRawFN_intWidth32'. (LINK-3)
Error: Unable to match ports of cell proc/h.z/vcore/fpu_float0/aux0/i2f/iNToRawFN/clz ('bsg_counting_leading_zeros') to 'bsg_counting_leading_zeros_width_p32'. (LINK-25)
