### PR TITLE
Update pipeline stage ordering

### DIFF
--- a/source/mulAddRecFN.v
+++ b/source/mulAddRecFN.v
@@ -490,7 +490,7 @@ module
     mulAddRecFN#(
         parameter expWidth = 3,
         parameter sigWidth = 3,
-        parameter int pipelineStages[0:1] = {0,0},
+     parameter int pipelineStages[1:0] = {0,0},
         parameter imulEn = 1'b1
     ) ( input clock,
         input [(`floatControlWidth - 1):0] control,


### PR DESCRIPTION
[0:1] order is unintuitive and likely to cause bugs (just did in BP...). This code was unused in BP and manycore, so the change shouldn't affect other projects unless @stdavids is using it.