### PR TITLE
Explicitly size sign bit

### DIFF
--- a/source/RISCV/HardFloat_specialize.vi
+++ b/source/RISCV/HardFloat_specialize.vi
@@ -44,6 +44,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /*----------------------------------------------------------------------------
 *----------------------------------------------------------------------------*/
-`define HardFloat_signDefaultNaN 0
+`define HardFloat_signDefaultNaN 1'b0
 `define HardFloat_fractDefaultNaN(sigWidth) {1'b1, {((sigWidth) - 2){1'b0}}}
 


### PR DESCRIPTION
This constant is currently unsized (32b).  It is used as the top bits of a concatenation, so it's doesn't cause problems with Synopsys tools. However it is against SystemVerilog LRM 11.4.12 (https://stackoverflow.com/questions/17939750/concatenation-of-the-constants-in-systemverilog). It causes issues in cadence tools