### PR TITLE
Converting logic to wire

### DIFF
--- a/source/HardFloat_rawFN.v
+++ b/source/HardFloat_rawFN.v
@@ -398,7 +398,6 @@ module
     $error("Intermediate rounding must be smaller than output");
   // synopsys translate_on
 
-  logic [(fullExpWidth + fullSigWidth):0] fullResult;
   roundAnyRawFNToRecFN
    #(.inExpWidth(fullExpWidth)
      ,.inSigWidth(fullSigWidth+2) // See the HardFloat docs for an explanation
@@ -421,8 +420,7 @@ module
      ,.exceptionFlags(fullExceptionFlags)
      );
 
-  logic [(midExpWidth + midSigWidth):0] midResult;
-  logic [4:0] midFlags;
+  wire [(midExpWidth + midSigWidth):0] midResult;
   roundAnyRawFNToRecFN
    #(.inExpWidth(fullExpWidth)
      ,.inSigWidth(fullSigWidth+2) // See the HardFloat docs for an explanation

--- a/source/iNToRecFN.v
+++ b/source/iNToRecFN.v
@@ -64,7 +64,7 @@ module
     wire [(expWidth - 2):0] adjustedNormDist;
     //countLeadingZeros#(extIntWidth, expWidth - 1)
     //    countLeadingZeros(extAbsIn, adjustedNormDist);
-    logic [$clog2(extIntWidth+1)-1:0] num_zero_lo;
+    wire [$clog2(extIntWidth+1)-1:0] num_zero_lo;
     bsg_counting_leading_zeros #(
       .width_p(extIntWidth)
     ) clz (


### PR DESCRIPTION
This PR converts logic to wire in a few modules in HardFloat. This makes the HardFloat modules pure Verilog which helps with tool compatibility. No functional change